### PR TITLE
Feat/xapi lrs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,7 @@ gem 'batch-loader', '~> 1.5' # Generic lazy batching mechanism to avoid N+1 DB q
 
 # GrowthTribe gems
 gem 'omniauth-keycloak', '~>1.2.0'
-gem 'xapi', '~>0.0.1' # Ruby library for implementing xAPIs Statements, Profiles and Querying Statements for LRS in simple way.
+gem 'xapi', '~>0.0.1', git: 'https://github.com/growthtribeacademy/Xapi.git', branch: 'master' # Ruby library for implementing xAPIs Statements, Profiles and Querying Statements for LRS in simple way.
 
 # Rails assets!
 source 'https://rails-assets.org' do

--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,7 @@ gem 'batch-loader', '~> 1.5' # Generic lazy batching mechanism to avoid N+1 DB q
 
 # GrowthTribe gems
 gem 'omniauth-keycloak', '~>1.2.0'
+gem 'xapi', '~>0.0.1' # Ruby library for implementing xAPIs Statements, Profiles and Querying Statements for LRS in simple way.
 
 # Rails assets!
 source 'https://rails-assets.org' do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -476,6 +476,7 @@ GEM
       execjs
       railties (>= 3.2)
       tilt
+    redcard (1.1.0)
     reform (2.3.3)
       disposable (>= 0.4.2, < 0.5.0)
       representable (>= 2.4.0, < 3.1.0)
@@ -639,6 +640,8 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xapi (0.0.1)
+      redcard (~> 1.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.4.1)
@@ -754,6 +757,7 @@ DEPENDENCIES
   webdrivers (~> 4.0)
   webmock (~> 3.5)
   webpacker (~> 5.2)
+  xapi (~> 0.0.1)
 
 RUBY VERSION
    ruby 2.7.2p137

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,14 @@
 GIT
+  remote: https://github.com/growthtribeacademy/Xapi.git
+  revision: 70a670ad8302e2a16f62594cb607b93131132000
+  branch: master
+  specs:
+    xapi (0.0.1)
+      addressable (~> 2.3)
+      faraday (~> 1.1.0)
+      ruby-duration (~> 3.2)
+
+GIT
   remote: https://github.com/mahesh-krishnakumar/bootstrap4-kaminari-views.git
   revision: 5ad07179ca22db5d17684f21096bcd0fddc6e289
   specs:
@@ -281,6 +291,7 @@ GEM
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
     iniparse (1.5.0)
+    iso8601 (0.13.0)
     jbuilder (2.10.1)
       activesupport (>= 5.0.0)
     jmespath (1.4.0)
@@ -476,7 +487,6 @@ GEM
       execjs
       railties (>= 3.2)
       tilt
-    redcard (1.1.0)
     reform (2.3.3)
       disposable (>= 0.4.2, < 0.5.0)
       representable (>= 2.4.0, < 3.1.0)
@@ -546,6 +556,10 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 0.87.0)
+    ruby-duration (3.2.3)
+      activesupport (>= 3.0.0)
+      i18n
+      iso8601
     ruby-graphviz (1.2.5)
       rexml
     ruby-progressbar (1.10.1)
@@ -640,8 +654,6 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    xapi (0.0.1)
-      redcard (~> 1.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.4.1)
@@ -757,7 +769,7 @@ DEPENDENCIES
   webdrivers (~> 4.0)
   webmock (~> 3.5)
   webpacker (~> 5.2)
-  xapi (~> 0.0.1)
+  xapi (~> 0.0.1)!
 
 RUBY VERSION
    ruby 2.7.2p137

--- a/app/jobs/timeline_events/after_marking_as_complete_job.rb
+++ b/app/jobs/timeline_events/after_marking_as_complete_job.rb
@@ -26,7 +26,6 @@ module TimelineEvents
     end
 
     def send_xapi_statement(event)
-      event.set_statement
       event.delay.persist
     end
   end

--- a/app/jobs/timeline_events/after_marking_as_complete_job.rb
+++ b/app/jobs/timeline_events/after_marking_as_complete_job.rb
@@ -6,9 +6,28 @@ module TimelineEvents
       # Refuse to process submissions from reviewed targets.
       return if submission.evaluation_criteria.exists?
 
+      user = submission.founders.first.user
+      send_xapi_statement(completed_target_event_for(user.to_xapi_agent, submission.target))
+
       if TimelineEvents::WasLastTargetService.new(submission).was_last_target?
+        send_xapi_statement(completed_course_event_for(user.to_xapi_agent, submission.target.course))
         Startups::IssueCertificateService.new(submission.founders.first.startup).execute
       end
+    end
+
+    private
+
+    def completed_target_event_for(user, target)
+      Xapi::CompletedTargetService.new(user, target)
+    end
+
+    def completed_course_event_for(user, course)
+      Xapi::CompletedProductService.new(user, course)
+    end
+
+    def send_xapi_statement(event)
+      event.set_statement
+      event.delay.persist
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -138,4 +138,8 @@ class User < ApplicationRecord
       title.presence || affiliation.presence
     end
   end
+
+  def to_xapi_agent
+    Xapi.create_agent(agent_type: 'Agent', email: email, name: name)
+  end
 end

--- a/app/services/courses/add_students_service.rb
+++ b/app/services/courses/add_students_service.rb
@@ -23,7 +23,7 @@ module Courses
         students = new_students.map do |student_data|
           student = create_new_student(student_data)
           create_keycloak_user(student_data.email,student_data.name)
-          register_event_for(student_data)
+          register_event_for(student.user)
 
           student
         end
@@ -131,7 +131,6 @@ module Courses
 
     def register_event_for(user)
       event = Xapi::RegisteredProductService.new(user.to_xapi_agent, @course)
-      event.set_statement
       event.delay.persist
     end
   end

--- a/app/services/xapi/base_service.rb
+++ b/app/services/xapi/base_service.rb
@@ -1,6 +1,7 @@
 module Xapi
   class BaseService
     include RoutesResolvable
+    attr_reader :agent, :object, :verb, :statement
 
     def persist
       Xapi.post_statement(remote_lrs: $remote_lrs, statement: @statement)

--- a/app/services/xapi/base_service.rb
+++ b/app/services/xapi/base_service.rb
@@ -1,0 +1,9 @@
+module Xapi
+  class BaseService
+    include RoutesResolvable
+
+    def persist
+      Xapi.post_statement(remote_lrs: $remote_lrs, statement: @statement)
+    end
+  end
+end

--- a/app/services/xapi/completed_product_service.rb
+++ b/app/services/xapi/completed_product_service.rb
@@ -1,0 +1,29 @@
+module Xapi
+  class CompletedProductService < Xapi::BaseService
+    def initialize(agent, course)
+      @agent = agent
+      @object = object(course)
+    end
+
+    def set_statement
+      @statement = Xapi.create_statement(actor: @agent, verb: verb, object: @object)
+    end
+
+    private
+
+    def verb
+      Xapi.create_verb(id: 'http://adlnet.gov/expapi/verbs/completed', name: 'completed')
+    end
+
+    def object(course)
+      params = {
+          id: url_helpers.course_url(course, host: course.school.domains.primary.fqdn),
+          name: course.title,
+          type: 'http://adlnet.gov/expapi/activities/product',
+          description: course.description,
+      }
+
+      Xapi.create_activity(params)
+    end
+  end
+end

--- a/app/services/xapi/completed_product_service.rb
+++ b/app/services/xapi/completed_product_service.rb
@@ -3,9 +3,6 @@ module Xapi
     def initialize(agent, course)
       @agent = agent
       @object = object(course)
-    end
-
-    def set_statement
       @statement = Xapi.create_statement(actor: @agent, verb: verb, object: @object)
     end
 

--- a/app/services/xapi/completed_target_service.rb
+++ b/app/services/xapi/completed_target_service.rb
@@ -1,0 +1,29 @@
+module Xapi
+  class CompletedTargetService < Xapi::BaseService
+    def initialize(agent, target)
+      @agent = agent
+      @object = object(target)
+    end
+
+    def set_statement
+      @statement = Xapi.create_statement(actor: @agent, verb: verb, object: @object)
+    end
+
+    private
+
+    def verb
+      Xapi.create_verb(id: 'https://w3id.org/xapi/dod-isd/verbs/completed-assignment', name: 'completed assignment')
+    end
+
+    def object(target)
+      params = {
+          id: url_helpers.target_url(target, host: target.course.school.domains.primary.fqdn),
+          name: target.title,
+          description: target.description,
+          type: "http://activitystrea.ms/schema/1.0/task"
+      }
+
+      Xapi.create_activity(params)
+    end
+  end
+end

--- a/app/services/xapi/completed_target_service.rb
+++ b/app/services/xapi/completed_target_service.rb
@@ -3,9 +3,6 @@ module Xapi
     def initialize(agent, target)
       @agent = agent
       @object = object(target)
-    end
-
-    def set_statement
       @statement = Xapi.create_statement(actor: @agent, verb: verb, object: @object)
     end
 

--- a/app/services/xapi/registered_product_service.rb
+++ b/app/services/xapi/registered_product_service.rb
@@ -1,12 +1,9 @@
 module Xapi
   class RegisteredProductService < Xapi::BaseService
+
     def initialize(agent, course)
       @agent = agent
-      @verb = verb
       @object = object(course)
-    end
-
-    def set_statement
       @statement = Xapi.create_statement(actor: @agent, verb: verb, object: @object)
     end
 

--- a/app/services/xapi/registered_product_service.rb
+++ b/app/services/xapi/registered_product_service.rb
@@ -1,0 +1,36 @@
+module Xapi
+  class RegisteredProductService < Xapi::BaseService
+    def initialize(agent, course)
+      @agent = agent
+      @verb = verb
+      @object = object(course)
+    end
+
+    def set_statement
+      @statement = Xapi.create_statement(actor: @agent, verb: verb, object: @object)
+    end
+
+    private
+
+    def verb
+      Xapi.create_verb(id: 'http://adlnet.gov/expapi/verbs/registered', name: 'registered')
+    end
+
+    def object(course)
+      params = {
+          id: url_helpers.course_url(course, host: course.school.domains.primary.fqdn),
+          name: course.name,
+          type: 'http://adlnet.gov/expapi/activities/product',
+          description: course.description
+      }
+
+      if course.ends_at.present?
+        elapsed_seconds = ((course.end_at - DateTime.now) * 24 * 60 * 60).to_i
+        iso8601_duration = ActiveSupport::Duration.build(elapsed_seconds).iso8601
+        params.merge!(extensions: { "http://id.tincanapi.com/extension/planned-duration" => iso8601_duration } )
+      end
+
+      Xapi.create_activity(params)
+    end
+  end
+end

--- a/config/initializers/xapi_lrs.rb
+++ b/config/initializers/xapi_lrs.rb
@@ -1,0 +1,5 @@
+$remote_lrs = Xapi.create_remote_lrs(
+    end_point: ENV['LRS_ENDPOINT'],
+    user_name: ENV['LRS_USERNAME'],
+    password: ENV['LRS_PASSWORD']
+)


### PR DESCRIPTION
This PR contains minimum requirement on Xapi events. 
In order to send event we are using a fork of  [this Gem](https://github.com/Deakin-Prime/Xapi).
Unfortunately, this Gem is not published anymore so you can find it under our GrowthTribe repository [here](https://github.com/growthtribeacademy/Xapi)

It sends xAPI event to LRS when: 
User is added to a course: `app/services/courses/add_students_service.rb`
User has completed a Target AND/OR a Course: `app/jobs/timeline_events/after_marking_as_complete_job.rb`

TODO: 
- Manage a verb <> URI config file
- tests

**Service added**
- Xapi/BaseService: Include RoutesResolvable and persist a xAPI statement
- Xapi/CompletedProductService
- Xapi/CompletedTargetService

**ENVs added:** 
`LRS_ENDPOINT`
`LRS_USERNAME`
`LRS_PASSWORD`