### PR TITLE
Fix/api student form

### DIFF
--- a/app/controllers/api/schools/courses_controller.rb
+++ b/app/controllers/api/schools/courses_controller.rb
@@ -18,11 +18,11 @@ module Api
       end
 
       def create_students
-        form = ::Schools::Founders::CreateForm.new(Reform::OpenForm.new)
+        form = Students::CreateForm.new(Reform::OpenForm.new)
 
-        response = if form.validate(params)
+        response = if form.validate(params.merge({notify: true}))
           student_count = form.save
-          { error: nil, studentCount: student_count }
+          { error: nil, studentIds: student_count }
         else
           { error: form.errors.full_messages.join(', ') }
         end

--- a/app/controllers/api/schools/courses_controller.rb
+++ b/app/controllers/api/schools/courses_controller.rb
@@ -2,11 +2,14 @@ module Api
   module Schools
     class CoursesController < SchoolsController
       skip_before_action :verify_authenticity_token
+      skip_after_action :verify_authorized
+
+      after_action :verify_authorized, except: :index
+      after_action :verify_policy_scoped, only: :index
       before_action :authenticate_user!
       before_action :set_course, only: [:students, :create_students]
 
       def index
-        skip_authorization
         render json: scope.to_json
       end
 

--- a/app/controllers/api/schools/courses_controller.rb
+++ b/app/controllers/api/schools/courses_controller.rb
@@ -23,17 +23,20 @@ module Api
       def create_students
         form = Students::CreateForm.new(Reform::OpenForm.new)
 
-        response = if form.validate(params.merge({notify: true}))
+        if form.validate(students_params.merge({notify: true}))
           student_count = form.save
-          { error: nil, studentIds: student_count }
+          render json: { error: nil, studentIds: student_count }, status: :created
         else
-          { error: form.errors.full_messages.join(', ') }
+          render json: { error: form.errors.full_messages.join(', ') }, status: :bad_request
         end
-
-        render json: response
       end
 
       private
+
+      def students_params
+        stds = params.require(:students).map { |p| p.permit(:name, :email) }
+        {course_id: @course.id, students: stds }
+      end
 
       def set_course
         @course = authorize(scope.find(params[:course_id]),

--- a/app/forms/api/schools/students/create_form.rb
+++ b/app/forms/api/schools/students/create_form.rb
@@ -1,0 +1,42 @@
+module Api
+  module Schools
+    module Students
+      class CreateForm < Reform::Form
+        property :course_id, validates: { presence: true }
+        property :notify
+
+        collection :students, populate_if_empty: OpenStruct, virtual: true, default: [] do
+          property :name, validates: { presence: true, length: { maximum: 250 } }
+          property :email, validates: { presence: true, length: { maximum: 250 }, format: { with: EmailValidator::REGULAR_EXPRESSION, message: "doesn't look like an email" } }
+          property :title
+          property :affiliation
+          property :tags
+          property :team_name, validates: { length: { maximum: 50 } }
+        end
+
+        validate :students_must_have_unique_email
+
+        def students_must_have_unique_email
+          return if students.map(&:email).uniq.count == students.count
+
+          errors[:base] << 'email addresses must be unique'
+        end
+
+        def save
+          ::Courses::AddStudentsService.new(course, notify: notify?).add(students)
+        end
+
+        private
+
+        def notify?
+          notify == 'true'
+        end
+
+        def course
+          @course ||= Course.find(course_id)
+        end
+      end
+    end
+  end
+
+end

--- a/app/forms/api/schools/students/create_form.rb
+++ b/app/forms/api/schools/students/create_form.rb
@@ -29,7 +29,7 @@ module Api
         private
 
         def notify?
-          notify == 'true'
+          notify.to_s == 'true'
         end
 
         def course

--- a/app/policies/schools/course_policy.rb
+++ b/app/policies/schools/course_policy.rb
@@ -18,6 +18,7 @@ module Schools
     alias exports? authors?
     alias certificates? authors?
     alias create_certificate? authors?
+    alias create_students? authors?
 
     def curriculum?
       return false if user.blank?

--- a/app/services/courses/add_students_service.rb
+++ b/app/services/courses/add_students_service.rb
@@ -1,5 +1,3 @@
-require 'keycloak'
-
 module Courses
   # Adds a list of new students to a course.
   class AddStudentsService

--- a/lib/devise/strategies/keycloak.rb
+++ b/lib/devise/strategies/keycloak.rb
@@ -3,6 +3,10 @@ require 'keycloak'
 module Devise
   module Strategies
     class Keycloak < Authenticatable
+      def valid?
+        request.path.match?(/^\/api/)
+      end
+
       def authenticate!
         return fail if request.headers['Authorization'].blank?
 

--- a/lib/keycloak.rb
+++ b/lib/keycloak.rb
@@ -256,6 +256,7 @@ module Keycloak
     def user_token(uname_email, password)
       user = user_by_email(uname_email)
       valid = user && user.dig(:credentials, :value) == password
+      raise FailedRequestError.new 'Failed to set user password' unless valid
       user[:token] = SecureRandom.uuid
     end
 

--- a/lib/keycloak.rb
+++ b/lib/keycloak.rb
@@ -233,7 +233,7 @@ module Keycloak
 
     def set_user_password(email, password)
       user = user_by_email(email)
-      raise FailedRequestError.new 'Failed to set user password' if user
+      raise FailedRequestError.new 'Failed to set user password' unless user
       user[:credentials] = {
         type: "password",
         temporary: false,
@@ -255,8 +255,7 @@ module Keycloak
 
     def user_token(uname_email, password)
       user = user_by_email(uname_email)
-      valid = user && user.dig(:credentials, :password) == password
-      raise FailedRequestError.new 'Failed to set user password' unless valid
+      valid = user && user.dig(:credentials, :value) == password
       user[:token] = SecureRandom.uuid
     end
 
@@ -269,7 +268,7 @@ module Keycloak
 
     private
     def user_by_token(token)
-      @users.find{|_, user| user[:token] == token}
+      @users.find{|_, user| user[:token] == token}[1]
     end
 
     def user_by_email(email)

--- a/spec/factories/course.rb
+++ b/spec/factories/course.rb
@@ -15,5 +15,11 @@ FactoryBot.define do
       progression_behavior { Course::PROGRESSION_BEHAVIOR_STRICT }
       progression_limit { nil }
     end
+
+    trait(:with_one_level) do
+      after(:create) do |course|
+        Level.where(course: course, number: 1).first_or_create!(name: 'Test Level')
+      end
+    end
   end
 end

--- a/spec/requests/api/schools/course_requests_spec.rb
+++ b/spec/requests/api/schools/course_requests_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+module Api
+  module Schools
+    describe 'Courses endpoints' do
+      let!(:keycloak_client) { Rails.configuration.keycloak_client }
+      let(:user_email) { 'test@test.com' }
+      let(:user_password) { 'testtest' }
+      let(:access_token) do
+        keycloak_client.user_token(user_email, user_password)
+      end
+      let(:headers) do
+        {
+          'ACCEPT' => 'application/json',
+          'Authorization' => "Bearer #{access_token}"
+        }
+      end
+      let!(:domain) { create :domain, fqdn: host, primary: true }
+      let!(:school) do
+        scl = domain.school
+
+        user = create :user, name: 'Test Test', email: user_email, school: scl
+        school_admin = create :school_admin, user: user
+
+        scl.school_admins << school_admin
+
+        scl
+      end
+
+      before :each do
+        keycloak_client.create_user(user_email, 'Test', 'Test')
+        keycloak_client.set_user_password(user_email, user_password)
+      end
+
+      context 'index' do
+        it 'returns all courses of current_school' do
+          courses = create_list :course, 3, school: school
+
+          get '/api/schools/courses', headers: headers
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to eq(courses.to_json)
+        end
+      end
+
+      context 'students' do
+        let!(:course) do
+          create :course, :with_one_level, school: school
+        end
+
+        let!(:students) do
+          student_structs = 4.times.map { |i| OpenStruct.new(name: "Test#{i}", email: "test#{i}@test.com") }
+          student_ids = ::Courses::AddStudentsService.new(course, notify: false).add(student_structs)
+          User.joins(:founders).where(founders: { id: student_ids })
+        end
+
+        it 'returns all students of a course' do
+          get "/api/schools/courses/#{course.id}/students", headers: headers
+
+          expected_students = students.map { |std| { name: std.name, email: std.email } }
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to eq({students: expected_students}.to_json)
+        end
+      end
+
+      context 'create_students' do
+        let!(:course) do
+          crs = create :course, :with_one_level, school: school
+        end
+
+        it 'register students into a course' do
+          params = {
+            students: [
+              {name: 'Test1', email: 'test1@test.com'},
+              {name: 'Test2', email: 'test2@test.com'}
+            ]
+          }
+          expect {
+            post "/api/schools/courses/#{course.id}/students", params: params, headers: headers
+          }.to change{ course.users.count }.by(2)
+          expect(response).to have_http_status(:created)
+        end
+
+        it 'always notify registered students' do
+          params = {
+            students: [
+              {name: 'Test1', email: 'test1@test.com'},
+              {name: 'Test2', email: 'test2@test.com'}
+            ]
+          }
+          form = Students::CreateForm.new(Reform::OpenForm.new) 
+          allow(Students::CreateForm).to receive(:new) { form }
+          expect(form).to receive(:validate).with(hash_including(notify: true)).and_call_original
+          post "/api/schools/courses/#{course.id}/students", params: params, headers: headers
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Proposed Changes

- Bring back Students::CreateForm to be used only be API. This form was removed by c8a36a658391e833723c497430c99ec231b2eea7
- Fix some of Keycloak::FakeClient methods

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Check if route, query, or mutation authorization looks correct.
  - Add tests for authorization, if required.
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Update developer and product docs, where applicable.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Check if new tables or columns that have been added need to be handled in the following services:
  - `Users::DeleteAccountService`
  - `Courses::CloneService`
  - `Courses::DeleteService`
  - `Courses::DemoContentService`
  - `Schools::DeleteService`
- [ ] Check if changes in _packaged_ components have been published to `npm`.
- [ ] Add development seeds for new tables.
